### PR TITLE
URLからのリポジトリクローン機能を追加

### DIFF
--- a/client/src/components/AddRepositoryDialog.tsx
+++ b/client/src/components/AddRepositoryDialog.tsx
@@ -10,8 +10,12 @@ import {
   Alert,
   IconButton,
   InputAdornment,
+  ToggleButton,
+  ToggleButtonGroup,
+  LinearProgress,
+  Typography,
 } from '@mui/material';
-import { FolderOpen } from '@mui/icons-material';
+import { FolderOpen, GitHub, Link } from '@mui/icons-material';
 import axios from 'axios';
 
 interface AddRepositoryDialogProps {
@@ -25,43 +29,90 @@ const AddRepositoryDialog: React.FC<AddRepositoryDialogProps> = ({
   onClose,
   onSuccess,
 }) => {
+  const [mode, setMode] = useState<'local' | 'url'>('local');
   const [name, setName] = useState('');
   const [path, setPath] = useState('');
+  const [url, setUrl] = useState('');
   const [description, setDescription] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [cloning, setCloning] = useState(false);
 
   const handleAdd = async () => {
-    if (!name || !path) {
-      setError('リポジトリ名とパスは必須です');
-      return;
-    }
+    if (mode === 'local') {
+      if (!name || !path) {
+        setError('リポジトリ名とパスは必須です');
+        return;
+      }
 
-    setLoading(true);
+      setLoading(true);
+      setError(null);
+
+      try {
+        await axios.post('/api/repositories', { name, path, description });
+        resetForm();
+        onClose();
+        onSuccess?.();
+      } catch (err: any) {
+        setError(err.response?.data?.error || 'リポジトリの追加に失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    } else {
+      if (!url) {
+        setError('リポジトリURLは必須です');
+        return;
+      }
+
+      setLoading(true);
+      setCloning(true);
+      setError(null);
+
+      try {
+        const response = await axios.post('/api/repositories/clone', { url, name, description });
+        console.log('Clone response:', response.data);
+        resetForm();
+        onClose();
+        onSuccess?.();
+      } catch (err: any) {
+        setError(err.response?.data?.error || 'リポジトリのクローンに失敗しました');
+      } finally {
+        setLoading(false);
+        setCloning(false);
+      }
+    }
+  };
+
+  const resetForm = () => {
+    setName('');
+    setPath('');
+    setUrl('');
+    setDescription('');
     setError(null);
-
-    try {
-      await axios.post('/api/repositories', { name, path, description });
-      setName('');
-      setPath('');
-      setDescription('');
-      onClose();
-      onSuccess?.();
-    } catch (err: any) {
-      setError(err.response?.data?.error || 'リポジトリの追加に失敗しました');
-    } finally {
-      setLoading(false);
-    }
   };
 
   const handleClose = () => {
     if (!loading) {
-      setName('');
-      setPath('');
-      setDescription('');
-      setError(null);
+      resetForm();
       onClose();
     }
+  };
+
+  const handleModeChange = (_: React.MouseEvent<HTMLElement>, newMode: 'local' | 'url' | null) => {
+    if (newMode !== null) {
+      setMode(newMode);
+      setError(null);
+    }
+  };
+
+  const validateUrl = (url: string): boolean => {
+    const githubPattern = /^https?:\/\/github\.com\/([\w.-]+)\/([\w.-]+)(\.git)?$/;
+    const gitlabPattern = /^https?:\/\/gitlab\.com\/([\w.-]+)\/([\w.-]+)(\.git)?$/;
+    const sshGithubPattern = /^git@github\.com:([\w.-]+)\/([\w.-]+)\.git$/;
+    const sshGitlabPattern = /^git@gitlab\.com:([\w.-]+)\/([\w.-]+)\.git$/;
+    
+    return githubPattern.test(url) || gitlabPattern.test(url) || 
+           sshGithubPattern.test(url) || sshGitlabPattern.test(url);
   };
 
   const handleSelectDirectory = () => {
@@ -76,40 +127,102 @@ const AddRepositoryDialog: React.FC<AddRepositoryDialogProps> = ({
       <DialogTitle>新規リポジトリを追加</DialogTitle>
       <DialogContent>
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <ToggleButtonGroup
+            value={mode}
+            exclusive
+            onChange={handleModeChange}
+            fullWidth
+            disabled={loading}
+          >
+            <ToggleButton value="local">
+              <FolderOpen sx={{ mr: 1 }} />
+              ローカルリポジトリ
+            </ToggleButton>
+            <ToggleButton value="url">
+              <Link sx={{ mr: 1 }} />
+              URLからクローン
+            </ToggleButton>
+          </ToggleButtonGroup>
+
           {error && <Alert severity="error">{error}</Alert>}
-          <TextField
-            label="リポジトリ名"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            fullWidth
-            placeholder="my-project"
-            helperText="表示用の名前"
-            disabled={loading}
-            required
-          />
-          <TextField
-            label="リポジトリパス"
-            value={path}
-            onChange={(e) => setPath(e.target.value)}
-            fullWidth
-            placeholder="/path/to/repository"
-            helperText="Gitリポジトリの絶対パス"
-            disabled={loading}
-            required
-            InputProps={{
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton
-                    onClick={handleSelectDirectory}
-                    edge="end"
-                    disabled={loading}
-                  >
-                    <FolderOpen />
-                  </IconButton>
-                </InputAdornment>
-              ),
-            }}
-          />
+
+          {cloning && (
+            <Box>
+              <Typography variant="body2" color="text.secondary" gutterBottom>
+                リポジトリをクローンしています...
+              </Typography>
+              <LinearProgress />
+            </Box>
+          )}
+
+          {mode === 'local' ? (
+            <>
+              <TextField
+                label="リポジトリ名"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                fullWidth
+                placeholder="my-project"
+                helperText="表示用の名前"
+                disabled={loading}
+                required
+              />
+              <TextField
+                label="リポジトリパス"
+                value={path}
+                onChange={(e) => setPath(e.target.value)}
+                fullWidth
+                placeholder="/path/to/repository"
+                helperText="Gitリポジトリの絶対パス"
+                disabled={loading}
+                required
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton
+                        onClick={handleSelectDirectory}
+                        edge="end"
+                        disabled={loading}
+                      >
+                        <FolderOpen />
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                }}
+              />
+            </>
+          ) : (
+            <>
+              <TextField
+                label="リポジトリURL"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                fullWidth
+                placeholder="https://github.com/username/repository.git"
+                helperText="GitHub/GitLabのリポジトリURL"
+                disabled={loading}
+                required
+                error={!!url && !validateUrl(url)}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <GitHub />
+                    </InputAdornment>
+                  ),
+                }}
+              />
+              <TextField
+                label="リポジトリ名（任意）"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                fullWidth
+                placeholder="my-project"
+                helperText="空欄の場合はURLから自動生成されます"
+                disabled={loading}
+              />
+            </>
+          )}
+
           <TextField
             label="説明"
             value={description}
@@ -129,9 +242,13 @@ const AddRepositoryDialog: React.FC<AddRepositoryDialogProps> = ({
         <Button
           onClick={handleAdd}
           variant="contained"
-          disabled={loading || !name || !path}
+          disabled={
+            loading ||
+            (mode === 'local' && (!name || !path)) ||
+            (mode === 'url' && !url)
+          }
         >
-          追加
+          {mode === 'local' ? '追加' : 'クローン'}
         </Button>
       </DialogActions>
     </Dialog>


### PR DESCRIPTION
- AddRepositoryDialogにローカル/URLモード選択機能を追加
- GitHub/GitLabからのリポジトリクローン機能を実装
- URL検証とクローン進行状況の表示機能を追加
- `/api/repositories/clone`エンドポイントを追加
- Git cloneコマンド実行とエラーハンドリングを実装

🤖 Generated with [Claude Code](https://claude.ai/code)