### PR TITLE
セッション状態変化時の通知機能を実装

### DIFF
--- a/client/src/components/NotificationSettings.tsx
+++ b/client/src/components/NotificationSettings.tsx
@@ -1,0 +1,111 @@
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  FormControlLabel,
+  Switch,
+  Stack,
+  Typography,
+  Alert,
+} from '@mui/material';
+import NotificationsIcon from '@mui/icons-material/Notifications';
+
+interface NotificationSettingsProps {
+  open: boolean;
+  onClose: () => void;
+  settings: {
+    enabled: boolean;
+    sound: boolean;
+    desktopNotifications: boolean;
+  };
+  permission: NotificationPermission;
+  onSettingsChange: (settings: any) => void;
+  onRequestPermission: () => Promise<boolean>;
+}
+
+export function NotificationSettings({
+  open,
+  onClose,
+  settings,
+  permission,
+  onSettingsChange,
+  onRequestPermission,
+}: NotificationSettingsProps) {
+  const handlePermissionRequest = async () => {
+    await onRequestPermission();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <NotificationsIcon />
+          <Typography variant="h6">通知設定</Typography>
+        </Stack>
+      </DialogTitle>
+      <DialogContent>
+        <Stack spacing={3}>
+          {permission === 'denied' && (
+            <Alert severity="warning">
+              ブラウザの通知が拒否されています。ブラウザの設定から許可してください。
+            </Alert>
+          )}
+          
+          {permission === 'default' && (
+            <Alert 
+              severity="info" 
+              action={
+                <Button color="inherit" size="small" onClick={handlePermissionRequest}>
+                  許可
+                </Button>
+              }
+            >
+              デスクトップ通知を使用するには許可が必要です。
+            </Alert>
+          )}
+
+          <FormControlLabel
+            control={
+              <Switch
+                checked={settings.enabled}
+                onChange={(e) => onSettingsChange({ enabled: e.target.checked })}
+              />
+            }
+            label="通知を有効にする"
+          />
+
+          <FormControlLabel
+            control={
+              <Switch
+                checked={settings.sound}
+                onChange={(e) => onSettingsChange({ sound: e.target.checked })}
+                disabled={!settings.enabled}
+              />
+            }
+            label="音声通知"
+          />
+
+          <FormControlLabel
+            control={
+              <Switch
+                checked={settings.desktopNotifications}
+                onChange={(e) => onSettingsChange({ desktopNotifications: e.target.checked })}
+                disabled={!settings.enabled || permission !== 'granted'}
+              />
+            }
+            label="デスクトップ通知"
+          />
+
+          <Typography variant="body2" color="text.secondary">
+            Claudeセッションが「待機中」または「入力待ち」になったときに通知します。
+          </Typography>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>閉じる</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/client/src/hooks/useNotifications.ts
+++ b/client/src/hooks/useNotifications.ts
@@ -1,0 +1,95 @@
+import { useEffect, useRef, useState } from 'react';
+import { NotificationEvent } from '../../../shared/types';
+
+interface NotificationSettings {
+  enabled: boolean;
+  sound: boolean;
+  desktopNotifications: boolean;
+}
+
+const DEFAULT_SETTINGS: NotificationSettings = {
+  enabled: true,
+  sound: true,
+  desktopNotifications: true,
+};
+
+export function useNotifications() {
+  const [settings, setSettings] = useState<NotificationSettings>(() => {
+    const saved = localStorage.getItem('notificationSettings');
+    return saved ? JSON.parse(saved) : DEFAULT_SETTINGS;
+  });
+  
+  const [permission, setPermission] = useState<NotificationPermission>(
+    'Notification' in window ? Notification.permission : 'denied'
+  );
+  
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    // 通知音を事前に読み込み
+    audioRef.current = new Audio('data:audio/wav;base64,UklGRhIFAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQoFAACCAHsAeQCAAGcAZgBfAGAAYgBhAGEAYgBkAGcAawBsAG0AcgB5AHoAeAB5AHgAeAB4AHgAegB8AH0AfQB+AHsAeQB5AHgAeAB4AHgAeAB9AIEAhACKAJEAlgCXAJsAn');
+  }, []);
+
+  const requestPermission = async () => {
+    if (!('Notification' in window)) {
+      console.warn('ブラウザが通知をサポートしていません');
+      return false;
+    }
+
+    if (Notification.permission === 'granted') {
+      setPermission('granted');
+      return true;
+    }
+
+    if (Notification.permission !== 'denied') {
+      const result = await Notification.requestPermission();
+      setPermission(result);
+      return result === 'granted';
+    }
+
+    return false;
+  };
+
+  const showNotification = (event: NotificationEvent) => {
+    if (!settings.enabled) return;
+
+    // 音声通知
+    if (settings.sound && audioRef.current) {
+      audioRef.current.play().catch(err => console.warn('音声再生エラー:', err));
+    }
+
+    // デスクトップ通知
+    if (settings.desktopNotifications && permission === 'granted') {
+      const title = event.toState === 'idle' 
+        ? 'Claudeが待機状態になりました' 
+        : 'Claudeが入力を待っています';
+      
+      const body = `ワークツリー: ${event.worktreePath}`;
+      
+      try {
+        new Notification(title, {
+          body,
+          icon: '/favicon.ico',
+          tag: event.sessionId,
+          requireInteraction: false,
+        });
+      } catch (err) {
+        console.error('通知表示エラー:', err);
+      }
+    }
+  };
+
+  const updateSettings = (newSettings: Partial<NotificationSettings>) => {
+    const updated = { ...settings, ...newSettings };
+    setSettings(updated);
+    localStorage.setItem('notificationSettings', JSON.stringify(updated));
+  };
+
+  return {
+    settings,
+    permission,
+    requestPermission,
+    showNotification,
+    updateSettings,
+  };
+}

--- a/client/src/pages/SessionManager.tsx
+++ b/client/src/pages/SessionManager.tsx
@@ -29,9 +29,10 @@ import {
   Circle,
   Menu as MenuIcon,
   Storage as StorageIcon,
+  Notifications as NotificationsIcon,
 } from '@mui/icons-material';
 import { io, Socket } from 'socket.io-client';
-import { Worktree, Session, Repository } from '../../../shared/types';
+import { Worktree, Session, Repository, NotificationEvent } from '../../../shared/types';
 import TerminalView from '../components/TerminalView';
 import CreateWorktreeDialog from '../components/CreateWorktreeDialog';
 import DeleteWorktreeDialog from '../components/DeleteWorktreeDialog';
@@ -42,6 +43,8 @@ import MobileDrawer from '../components/MobileDrawer';
 import useBreakpoint from '../hooks/useBreakpoint';
 import AddRepositoryDialog from '../components/AddRepositoryDialog';
 import RepositoryManagementDialog from '../components/RepositoryManagementDialog';
+import { NotificationSettings } from '../components/NotificationSettings';
+import { useNotifications } from '../hooks/useNotifications';
 
 const drawerWidth = 300;
 
@@ -61,6 +64,8 @@ const SessionManager: React.FC = () => {
   const [repositoryManagementDialogOpen, setRepositoryManagementDialogOpen] = useState(false);
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
   const [mobileNavValue, setMobileNavValue] = useState(0);
+  const [notificationSettingsOpen, setNotificationSettingsOpen] = useState(false);
+  const notifications = useNotifications();
 
   useEffect(() => {
     const newSocket = io();
@@ -108,6 +113,10 @@ const SessionManager: React.FC = () => {
         }
         return prevSession;
       });
+    });
+
+    newSocket.on('notification:show', (event: NotificationEvent) => {
+      notifications.showNotification(event);
     });
 
     return () => {
@@ -266,6 +275,13 @@ const SessionManager: React.FC = () => {
           <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
             {selectedWorktree ? selectedWorktree.branch : 'Claude Code Crew'}
           </Typography>
+          <IconButton
+            color="inherit"
+            onClick={() => setNotificationSettingsOpen(true)}
+            sx={{ mr: 1 }}
+          >
+            <NotificationsIcon />
+          </IconButton>
           {activeSession && (
             <Chip
               label={activeSession.state.replace('_', ' ')}
@@ -493,6 +509,15 @@ const SessionManager: React.FC = () => {
         onClose={() => setRepositoryManagementDialogOpen(false)}
         repositories={repositories}
         selectedRepository={selectedRepository}
+      />
+      
+      <NotificationSettings
+        open={notificationSettingsOpen}
+        onClose={() => setNotificationSettingsOpen(false)}
+        settings={notifications.settings}
+        permission={notifications.permission}
+        onSettingsChange={notifications.updateSettings}
+        onRequestPermission={notifications.requestPermission}
       />
       
       {isMobile && (

--- a/server/src/websocket/index.ts
+++ b/server/src/websocket/index.ts
@@ -1,5 +1,5 @@
 import { Server, Socket } from 'socket.io';
-import { SessionManager } from '../services/sessionManager.js';
+import { SessionManager, NotificationEvent } from '../services/sessionManager.js';
 import { WorktreeService } from '../services/worktreeService.js';
 import { RepositoryService } from '../services/repositoryService.js';
 import { Session, Worktree } from '../../../shared/types.js';
@@ -95,6 +95,12 @@ export async function setupWebSocket(io: Server, sessionManager: SessionManager)
     console.log(`Session disconnected: ${session.id}`);
     io.emit('session:disconnected', session);
     io.emit('worktrees:updated', getWorktreesWithSessions());
+  });
+
+  // 通知イベント
+  sessionManager.on('notification', (event: NotificationEvent) => {
+    console.log(`Notification event: ${event.sessionId} ${event.fromState} -> ${event.toState}`);
+    io.emit('notification:show', event);
   });
 
   // Socket connection handler

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -77,3 +77,11 @@ export interface SessionPersistenceData {
   outputHistory?: string[]; // Base64エンコードされた出力履歴
   environment?: Record<string, string>; // 環境変数
 }
+
+export interface NotificationEvent {
+  sessionId: string;
+  worktreePath: string;
+  fromState: SessionState;
+  toState: SessionState;
+  timestamp: Date;
+}


### PR DESCRIPTION
- 通知設定UIコンポーネント（NotificationSettings.tsx）を追加
- 通知フック（useNotifications.ts）で音声・デスクトップ通知を実装
- SessionManagerに通知機能を統合し、設定UIを追加
- サーバー側でセッション状態変化時の通知イベント送信機能を追加
- WebSocketで通知イベントを配信
- busy→idle/waiting_input時に通知を表示

🤖 Generated with [Claude Code](https://claude.ai/code)
